### PR TITLE
Allow 'Archive' action on Archive folders with hidden option

### DIFF
--- a/src/content/autoArchivePref.jsm
+++ b/src/content/autoArchivePref.jsm
@@ -90,7 +90,7 @@ let autoArchivePref = {
   prefPath: "extensions.awsome_auto_archive.",
   allPrefs: ['enable_verbose_info', 'rules', 'rules_to_keep', 'enable_flag', 'enable_tag', 'enable_unread', 'age_flag', 'age_tag', 'age_unread', 'startup_delay', 'idle_delay', 'check_servers', 'update_folders',
              'start_next_delay', 'rule_timeout', 'generate_rule_use', 'show_from', 'show_recipient', 'show_subject', 'show_size', 'show_tags', 'show_age', 'delete_duplicate_in_src', 'ignore_spam_folders',
-             'update_statusbartext', 'default_days', 'dry_run', 'messages_number_limit', 'messages_size_limit', 'start_exceed_delay', 'show_folder_as', 'add_context_munu_rule', 'alert_show_time', 'hibernate'],
+             'update_statusbartext', 'default_days', 'dry_run', 'messages_number_limit', 'messages_size_limit', 'start_exceed_delay', 'show_folder_as', 'add_context_munu_rule', 'alert_show_time', 'hibernate', 'archive_archive_folders'],
   complexPrefs: {'rules': Ci.nsISupportsString },
   observe: function(subject, topic, key) {
     try {
@@ -111,6 +111,7 @@ let autoArchivePref = {
         case 'show_age':
         case 'delete_duplicate_in_src':
         case 'ignore_spam_folders':
+        case 'archive_archive_folders':
         case 'update_folders':
         case 'check_servers':
           this.options[key] = this.prefs.getBoolPref(key);

--- a/src/content/autoArchiveService.jsm
+++ b/src/content/autoArchiveService.jsm
@@ -855,7 +855,7 @@ let autoArchiveService = {
           if ( folder.getFlag(Ci.nsMsgFolderFlags.Virtual) ) continue;
           if ( autoArchivePref.options.ignore_spam_folders && ["move", "archive", "copy"].indexOf(rule.action) >= 0 &&
             folder.getFlag(Ci.nsMsgFolderFlags.Trash | Ci.nsMsgFolderFlags.Junk| Ci.nsMsgFolderFlags.Queue | Ci.nsMsgFolderFlags.Drafts | Ci.nsMsgFolderFlags.Templates ) ) continue;
-          if ( rule.action == 'archive' && self.folderIsOf(folder, Ci.nsMsgFolderFlags.Archive) ) continue;
+          if ( rule.action == 'archive' && self.folderIsOf(folder, Ci.nsMsgFolderFlags.Archive) && !autoArchivePref.options.archive_archive_folders ) continue;
           searchSession.addScopeTerm(Ci.nsMsgSearchScope.offlineMail, folder);
           self.accessedFolders[folder.URI] = true;
           self.wait4Folders[folder.URI] = (rule.action == 'copy' ? 2 : true);

--- a/src/content/autoArchiveService.jsm
+++ b/src/content/autoArchiveService.jsm
@@ -827,7 +827,7 @@ let autoArchiveService = {
       let virtFolder = VirtualFolderHelper.wrapVirtualFolder(srcFolder);
       let scope = virtFolder.onlineSearch ? Ci.nsMsgSearchScope.onlineMail : Ci.nsMsgSearchScope.offlineMail;
       virtFolder.searchFolders.forEach( function(folder) {
-        if ( rule.action == 'archive' && self.folderIsOf(folder, Ci.nsMsgFolderFlags.Archive) ) return;
+        if ( rule.action == 'archive' && self.folderIsOf(folder, Ci.nsMsgFolderFlags.Archive) && !autoArchivePref.options.archive_archive_folders ) return;
         autoArchiveLog.info("Add src folder " + folder.URI);
         searchSession.addScopeTerm(scope, folder);
         self.accessedFolders[folder.URI] = true;

--- a/src/content/autoArchiveService.jsm
+++ b/src/content/autoArchiveService.jsm
@@ -423,7 +423,7 @@ let autoArchiveService = {
         if ( typeof(rule.tags) == 'undefined' && this.hasTag(msgHdr) && ( !autoArchivePref.options.enable_tag || age < autoArchivePref.options.age_tag ) ) return skipReason.tags++;
       }
       if ( rule.action == 'archive' ) {
-        if ( self.folderIsOf(msgHdr.folder, Ci.nsMsgFolderFlags.Archive) ) return skipReason.cantArchive++;
+        if ( self.folderIsOf(msgHdr.folder, Ci.nsMsgFolderFlags.Archive) && !autoArchivePref.options.archive_archive_folders ) return skipReason.cantArchive++;
         let getIdentityForHeader = mail3PaneWindow.getIdentityForHeader || mail3PaneWindow.GetIdentityForHeader; // TB & SeaMonkey use different name
         if ( !getIdentityForHeader || !getIdentityForHeader(msgHdr).archiveEnabled ) return skipReason.cantArchive++;
       }

--- a/src/defaults/preferences/prefs.js
+++ b/src/defaults/preferences/prefs.js
@@ -30,5 +30,6 @@ pref("extensions.awsome_auto_archive.show_size", false);
 pref("extensions.awsome_auto_archive.show_tags", false);
 pref("extensions.awsome_auto_archive.show_age", true);
 pref("extensions.awsome_auto_archive.ignore_spam_folders", true);
+pref("extensions.awsome_auto_archive.archive_archive_folders", false); // hidden config, allow 'Archive' action on archive-type folders
 pref("extensions.awsome_auto_archive.check_servers", true); // hidden config, check if server online before move/delete
 pref("extensions.awsome_auto_archive.update_folders", true); // hidden config, update folder before/after move/copy etc


### PR DESCRIPTION
There are some use cases where being able to use the 'Archive' option on an Archive-type folder makes sense.

For example, I have a Gmail IMAP account with a custom "Archive" action that archives to a local folder keeping the folder structure and organizing by year. This goes well beyond the "Move/Copy" functionality of Auto Awesome. But using AutoAwesome to call the "Archive" action skips the "All Mail" folder due to the latter being classified as an Archive-type folder by Thunderbird.

This use case would not create a recursive loop of archives (I'm guessing the intent of the check), as the custom archive destination is not part of the IMAP account folder structure.

As this seems like a rather edge-case need, I added an option that toggles this bypass, and set the default behavior to the original implimentation (skipping Archive-type folders for the 'Archive' action). However, for users that might want to enable this feature, they can do so by toggling the option directly in Thunderbird's Configuration Manager.
