### PR TITLE
fix str not defined

### DIFF
--- a/src/content/autoArchivePref.jsm
+++ b/src/content/autoArchivePref.jsm
@@ -80,7 +80,7 @@ let autoArchivePref = {
             str.data = value;
             this.prefs.setComplexValue(key, this.complexPrefs[key], str);
           } else {
-            this.prefs.setStringPref(key, str);
+            this.prefs.setStringPref(key, value);
           }
         }
         else this.prefs.setCharPref(key, value);


### PR DESCRIPTION
When setting Preferences from git build on TB 60 The following error is thrown:

```
Caught Exception ReferenceError: str is not defined
setPerf@chrome://awsomeautoarchive/content/autoArchivePref.jsm:83:13
acceptPerfWindow@chrome://awsomeautoarchive/content/autoArchivePrefDialog.jsm:569:33
anonymous@chrome://global/content/bindings/dialog.xml line 407 > Function:3:8
_fireButtonEvent@chrome://global/content/bindings/dialog.xml:408:28
_doButtonCommand@chrome://global/content/bindings/dialog.xml:376:28
_handleButtonCommand@chrome://global/content/bindings/dialog.xml:364:18
openOption@chrome://awsomeautoarchive/content/autoArchive.jsm:185:5
createPopup/<@chrome://awsomeautoarchive/content/autoArchive.jsm:232:82
```